### PR TITLE
Add overclocked frequencies: 720, 805 and 850MHz using turbo mode

### DIFF
--- a/arch/arm/boot/dts/omap34xx.dtsi
+++ b/arch/arm/boot/dts/omap34xx.dtsi
@@ -25,51 +25,52 @@
 		compatible = "operating-points-v2-ti-cpu";
 		syscon = <&scm_conf>;
 
-		opp1-125000000 {
-			opp-hz = /bits/ 64 <125000000>;
-			/*
-			 * we currently only select the max voltage from table
-			 * Table 3-3 of the omap3530 Data sheet (SPRS507F).
-			 * Format is: <target min max>
-			 */
-			opp-microvolt = <975000 975000 975000>;
-			/*
-			 * first value is silicon revision bit mask
-			 * second one 720MHz Device Identification bit mask
-			 */
-			opp-supported-hw = <0xffffffff 3>;
-		};
-
-		opp2-250000000 {
+		opp1-250000000 {
 			opp-hz = /bits/ 64 <250000000>;
 			opp-microvolt = <1075000 1075000 1075000>;
 			opp-supported-hw = <0xffffffff 3>;
 			opp-suspend;
 		};
 
-		opp3-500000000 {
+		opp2-500000000 {
 			opp-hz = /bits/ 64 <500000000>;
 			opp-microvolt = <1200000 1200000 1200000>;
 			opp-supported-hw = <0xffffffff 3>;
 		};
 
-		opp4-550000000 {
+		opp3-550000000 {
 			opp-hz = /bits/ 64 <550000000>;
 			opp-microvolt = <1275000 1275000 1275000>;
 			opp-supported-hw = <0xffffffff 3>;
 		};
 
-		opp5-600000000 {
+		opp4-600000000 {
 			opp-hz = /bits/ 64 <600000000>;
 			opp-microvolt = <1350000 1350000 1350000>;
 			opp-supported-hw = <0xffffffff 3>;
 		};
 
-		opp6-720000000 {
+		opp5-720000000 {
 			opp-hz = /bits/ 64 <720000000>;
 			opp-microvolt = <1350000 1350000 1350000>;
 			/* only high-speed grade omap3530 devices */
-			opp-supported-hw = <0xffffffff 2>;
+			opp-supported-hw = <0xffffffff 3>;
+			turbo-mode;
+		};
+
+		opp6-805000000 {
+			opp-hz = /bits/ 64 <805000000>;
+			opp-microvolt = <1350000 1350000 1350000>;
+			/* only high-speed grade omap3530 devices */
+			opp-supported-hw = <0xffffffff 3>;
+			turbo-mode;
+		};
+
+		opp7-850000000 {
+			opp-hz = /bits/ 64 <850000000>;
+			opp-microvolt = <1350000 1350000 1350000>;
+			/* only high-speed grade omap3530 devices */
+			opp-supported-hw = <0xffffffff 3>;
 			turbo-mode;
 		};
 	};


### PR DESCRIPTION
Boost frequencies are deactivated on boot.
This way the max boot frequency stays at 600MHz.
To activate boost frequencies:
echo 1 > /sys/devices/system/cpu/cpufreq/boost