### PR TITLE
(v2)Add overclocked frequencies: 720, 805 and 850MHz using turbo mode

### DIFF
--- a/arch/arm/boot/dts/omap3-n900.dts
+++ b/arch/arm/boot/dts/omap3-n900.dts
@@ -1172,3 +1172,67 @@
 &ssi_port2 {
 	status = "disabled";
 };
+
+&cpus {
+	cpu: cpu@0 {
+		operating-points-v2 = <&cpu0_opp_table>;
+
+		clock-latency = <300000>; /* From legacy driver */
+		#cooling-cells = <2>;
+	};
+};
+
+&cpu0_opp_table: opp-table {
+	compatible = "operating-points-v2-ti-cpu";
+	syscon = <&scm_conf>;
+
+	opp1-125000000 {
+		status = "disabled";
+	};
+
+	opp2-250000000 {
+		opp-hz = /bits/ 64 <250000000>;
+		opp-microvolt = <1075000 1075000 1075000>;
+		opp-supported-hw = <0xffffffff 3>;
+		opp-suspend;
+	};
+
+	opp3-500000000 {
+		opp-hz = /bits/ 64 <500000000>;
+		opp-microvolt = <1200000 1200000 1200000>;
+		opp-supported-hw = <0xffffffff 3>;
+	};
+
+	opp4-550000000 {
+		opp-hz = /bits/ 64 <550000000>;
+		opp-microvolt = <1275000 1275000 1275000>;
+		opp-supported-hw = <0xffffffff 3>;
+	};
+
+	opp5-600000000 {
+		opp-hz = /bits/ 64 <600000000>;
+		opp-microvolt = <1350000 1350000 1350000>;
+		opp-supported-hw = <0xffffffff 3>;
+	};
+
+	opp6-720000000 {
+		opp-hz = /bits/ 64 <720000000>;
+		opp-microvolt = <1350000 1350000 1350000>;
+		opp-supported-hw = <0xffffffff 3>;
+		turbo-mode;
+	};
+
+	opp7-805000000 {
+		opp-hz = /bits/ 64 <805000000>;
+		opp-microvolt = <1350000 1350000 1350000>;
+		opp-supported-hw = <0xffffffff 3>;
+		turbo-mode;
+	};
+
+	opp8-850000000 {
+		opp-hz = /bits/ 64 <850000000>;
+		opp-microvolt = <1350000 1350000 1350000>;
+		opp-supported-hw = <0xffffffff 3>;
+		turbo-mode;
+	};
+};


### PR DESCRIPTION
Boost frequencies are deactivated on boot.
This way the max boot frequency stays at 600MHz