### PR TITLE
Update omap3-n900.dts: new typo in opp table

### DIFF
--- a/arch/arm/boot/dts/ti/omap/omap3-n900.dts
+++ b/arch/arm/boot/dts/ti/omap/omap3-n900.dts
@@ -1178,51 +1178,44 @@
 	compatible = "operating-points-v2-ti-cpu";
 	syscon = <&scm_conf>;
 
-	opp1-125000000 {
+	opp-125000000 {
 		status = "disabled";
 	};
 
-	opp2-250000000 {
+	opp-250000000 {
 		opp-hz = /bits/ 64 <250000000>;
 		opp-microvolt = <1075000 1075000 1075000>;
 		opp-supported-hw = <0xffffffff 3>;
 		opp-suspend;
 	};
 
-	opp3-500000000 {
+	opp-500000000 {
 		opp-hz = /bits/ 64 <500000000>;
 		opp-microvolt = <1200000 1200000 1200000>;
 		opp-supported-hw = <0xffffffff 3>;
 	};
 
-	opp4-550000000 {
+	opp-550000000 {
 		opp-hz = /bits/ 64 <550000000>;
 		opp-microvolt = <1275000 1275000 1275000>;
 		opp-supported-hw = <0xffffffff 3>;
 	};
 
-	opp5-600000000 {
+	opp-600000000 {
 		opp-hz = /bits/ 64 <600000000>;
 		opp-microvolt = <1350000 1350000 1350000>;
 		opp-supported-hw = <0xffffffff 3>;
 	};
 
-	opp6-720000000 {
+	opp-720000000 {
 		opp-hz = /bits/ 64 <720000000>;
 		opp-microvolt = <1350000 1350000 1350000>;
 		opp-supported-hw = <0xffffffff 3>;
 		turbo-mode;
 	};
 
-	opp7-805000000 {
+	opp-805000000 {
 		opp-hz = /bits/ 64 <805000000>;
-		opp-microvolt = <1350000 1350000 1350000>;
-		opp-supported-hw = <0xffffffff 3>;
-		turbo-mode;
-	};
-
-	opp8-850000000 {
-		opp-hz = /bits/ 64 <850000000>;
 		opp-microvolt = <1350000 1350000 1350000>;
 		opp-supported-hw = <0xffffffff 3>;
 		turbo-mode;


### PR DESCRIPTION
use opp-xxx instead of opp1-xxx, opp2-xxx... to avoid duplicate opp's. Duplicate opp's and 125MHz freq seem to make N900 unstable. 850MHz freq has been removed since some devices are not able to run at more than 805MHz.